### PR TITLE
swapped links on windows and linux Priv Esc course links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ New Capstone boxes: https://drive.google.com/drive/folders/1VXEuyySgzsSo-MYmyCar
 
 Old Capstone boxes: https://youtu.be/JZN3JhoAdWo
 
-Linux Priv Esc course: https://academy.tcm-sec.com/p/windows-privilege-escalation-for-beginners
+Windows Priv Esc course: https://academy.tcm-sec.com/p/windows-privilege-escalation-for-beginners
 
-Windows Priv Esc Course: https://academy.tcm-sec.com/p/linux-privilege-escalation
+Linux Priv Esc Course: https://academy.tcm-sec.com/p/linux-privilege-escalation
 
 ### Introduction to Exploit Development (Buffer Overflows)
 Immunity Debugger: https://www.immunityinc.com/products/debugger/


### PR DESCRIPTION
The descriptions and the links to the resourcers were swapped!!

The original:
![links](https://github.com/user-attachments/assets/2373dcdf-9b29-4022-ba00-d8f52fc3565d)



The fixed.
![links fixed](https://github.com/user-attachments/assets/aeeb8d55-f109-431e-867b-9ee32836b791)


